### PR TITLE
Added new flag for different tool deployment name

### DIFF
--- a/find_orphan_rbd_images.sh
+++ b/find_orphan_rbd_images.sh
@@ -16,7 +16,7 @@ VERSION="0.15"
 ###############################################################################
 
 # ---[ Init Routines ]---------------------------------------------------------
-required_utils=("kubectl" "kubectl-rook_ceph")
+required_utils=("kubectl")
 
 # Confirm required utilities are installed.
 for util in "${required_utils[@]}"; do


### PR DESCRIPTION
I have a situation where the name of the name of the tools deployment is non-standard, so I added a flag to be able to specify that. The default behavior is the same as previous so it shouldn't change anything :) 

I also removed the requirement for `kubectl_rook-ceph` since I can't find anywhere that is used :thinking: Or maybe I'm just bad at looking :see_no_evil: 